### PR TITLE
Add font-size-base adjuster

### DIFF
--- a/parts/tokens/tokens.11ty.js
+++ b/parts/tokens/tokens.11ty.js
@@ -89,14 +89,15 @@ const variables = (jsonTokens) => ` /* CSS Variables */
   --space-unit-x16: calc(${jsonTokens.spacing.unit} * 16);
 
   /* typography variables */
-  --font-family:  ${jsonTokens.typography.font};
-  --text-max-width:  ${jsonTokens.typography.text_max_width};
-  --ratio:  ${jsonTokens.typography.ratio};
-  --font-size-base: calc(${jsonTokens.typography.font_size_base} + .2vw);
+  --font-family: ${jsonTokens.typography.font};
+  --text-max-width: ${jsonTokens.typography.text_max_width};
+  --ratio: ${jsonTokens.typography.ratio};
+  --font-size-base: ${jsonTokens.typography.font_size_base}; /* Adjust font-size-base, default 1rem. */
+  --font-size-base-responsive: calc(var(--font-size-base) + .2vw);
 
   /* font-size scale */
-  --text-size-small: calc(var(--font-size-base) - .1em);
-  --text-size-1: var(--font-size-base);
+  --text-size-small: calc(var(--font-size-base-responsive) - .1em);
+  --text-size-1: var(--font-size-base-responsive);
   --text-size-2: calc(var(--text-size-1) * var(--ratio));
   --text-size-3: calc(var(--text-size-2) * var(--ratio));
   --text-size-4: calc(var(--text-size-3) * var(--ratio));

--- a/parts/tokens/tokens.html
+++ b/parts/tokens/tokens.html
@@ -1,5 +1,0 @@
-<link rel="stylesheet" href="/parts/base/base.css" />
-<link rel="stylesheet" href="tokens.css" />
-
-<section>
-</section>


### PR DESCRIPTION
Adds in the font-size-adjuster from Ryan's original typography [codepen](https://codepen.io/Ryan-Hamilton-the-selector/pen/oNOVxbz). It works a little bit differently here compared to the pen. 

In the pen, the `--font-size-adjustment` is a separate value that's added to (or subtracted from) `.7rem`. The default is `.3rem`. So `.7rem + .3rem` comes out to `1rem`.

Here, we're just making `--font-size-base` a whole number that can be adjusted. And the default is `1rem`. Anyone who wants to customize this can just change that base number, instead of doing addition/subtraction. I think it's a little bit easier to document and reason about it this way.