### PR TITLE
Make forms more practical

### DIFF
--- a/pages/elements.html
+++ b/pages/elements.html
@@ -67,109 +67,165 @@
 	<h2>Forms</h2>
 
 	<form action="" method="get">
-		<label for="text">Enter some text:</label>
-		<input type="text" name="text" id="text" required />
+		<ca-form-field>
+			<label for="text">Enter some text:</label>
+			<input type="text" name="text" id="text" required invalid />
+			<p><small>Enter whatever text you like. But you must enter something!</small></p>
+		</ca-form-field>
 
-		<label for="textarea">Enter more text:</label>
-		<textarea name="textarea" id="textarea">Replace this default text...</textarea>
+		<!-- `div.ca-form-field` also works. Have our cake and eat it too. -->
+		<div class="ca-form-field">
+			<label for="textarea">Enter more text:</label>
+			<textarea name="textarea" id="textarea">Replace this default text...</textarea>
+		</div>
 
-		<label for="email">Enter your email:</label>
-		<input type="email" name="email" id="email" required />
+		<ca-form-field>
+			<label for="email">Enter your email:</label>
+			<input type="email" name="email" id="email" required />
+		</ca-form-field>
 
-		<label for="password">Enter your password:</label>
-		<input type="password" name="password" id="password" required />
+		<ca-form-field>
+			<label for="password">Enter your password:</label>
+			<input type="password" name="password" id="password" required />
+		</ca-form-field>
 
-		<label for="date">Pick a date: </label>
-		<input type="date" name="date" id="date" />
+		<ca-form-field>
+			<label for="date">Pick a date: </label>
+			<input type="date" name="date" id="date" />
+		</ca-form-field>
 
-		<label for="datetime">Pick a date and time:</label>
-		<input type="datetime-local" name="datetime" id="datetime" />
+		<ca-form-field>
+			<label for="datetime">Pick a date and time:</label>
+			<input type="datetime-local" name="datetime" id="datetime" />
+		</ca-form-field>
 
-		<label for="month">Pick a month:</label>
-		<input type="month" name="month" id="month" />
+		<ca-form-field>
+			<label for="month">Pick a month:</label>
+			<input type="month" name="month" id="month" />
+		</ca-form-field>
 
-		<label for="week">Pick a week:</label>
-		<input type="week" name="week" id="week" />
+		<ca-form-field>
+			<label for="week">Pick a week:</label>
+			<input type="week" name="week" id="week" />
+		</ca-form-field>
 
-		<label for="time">Pick a time:</label>
-		<input type="time" name="time" id="time" />
+		<ca-form-field>
+			<label for="time">Pick a time:</label>
+			<input type="time" name="time" id="time" />
+		</ca-form-field>
 
-		<label for="number">Pick a number:</label>
-		<input type="number" name="number" id="number" />
+		<ca-form-field>
+			<label for="number">Pick a number:</label>
+			<input type="number" name="number" id="number" />
+		</ca-form-field>
 
-		<label for="tel">Enter a telephone number:</label>
-		<input type="tel" name="tel" id="tel" />
+		<ca-form-field>
+			<label for="tel">Enter a telephone number:</label>
+			<input type="tel" name="tel" id="tel" />
+		</ca-form-field>
 
-		<input type="checkbox" name="checkbox" id="checkbox" />
-		<label for="checkbox">I agree to the whatever.</label>
+		<ca-form-field>
+			<input type="checkbox" name="checkbox" id="checkbox" />
+			<label for="checkbox">I agree to the whatever.</label>
+			<p><small>By agreeing to the whatever, you will also be bound by the additional whatevers of this small
+					print.</small></p>
+		</ca-form-field>
 
-		<input type="radio" name="radio" id="radio" />
-		<label for="radio">I select this default single option against my will.</label>
+		<ca-form-field>
+			<input type="radio" name="radio" id="radio" />
+			<label for="radio">I select this default single option against my will.</label>
+		</ca-form-field>
 
 		<fieldset>
 			<legend>Choose your favorite condiments:</legend>
 
-			<input type="checkbox" id="mustard" name="condiments" value="mustard" />
-			<label for="mustard">Mustard</label>
+			<ca-form-field>
+				<input type="checkbox" id="mustard" name="condiments" value="mustard" />
+				<label for="mustard">Mustard</label>
+			</ca-form-field>
 
-			<input type="checkbox" id="wasabi" name="condiments" value="wasabi" />
-			<label for="wasabi">Wasabi</label>
+			<ca-form-field>
+				<input type="checkbox" id="wasabi" name="condiments" value="wasabi" />
+				<label for="wasabi">Wasabi</label>
+			</ca-form-field>
 
-			<input type="checkbox" id="horshradish" name="condiments" value="horshradish" />
-			<label for="horshradish">Horseradish</label>
+			<ca-form-field>
+				<input type="checkbox" id="horshradish" name="condiments" value="horshradish" />
+				<label for="horshradish">Horseradish</label>
+			</ca-form-field>
 		</fieldset>
 
 		<fieldset>
 			<legend>What's the correct spelling?</legend>
 
-			<input type="radio" id="ketchup" name="spelling" value="ketchup" />
-			<label for="ketchup">Ketchup</label>
+			<ca-form-field>
+				<input type="radio" id="ketchup" name="spelling" value="ketchup" />
+				<label for="ketchup">Ketchup</label>
+			</ca-form-field>
 
-			<input type="radio" id="catsup" name="spelling" value="catsup" />
-			<label for="catsup">Catsup</label>
+			<ca-form-field>
+				<input type="radio" id="catsup" name="spelling" value="catsup" />
+				<label for="catsup">Catsup</label>
+			</ca-form-field>
 
-			<input type="radio" id="what" name="spelling" value="what" />
-			<label for="what">What's up?</label>
+			<ca-form-field>
+				<input type="radio" id="what" name="spelling" value="what" />
+				<label for="what">What's up?</label>
+			</ca-form-field>
 		</fieldset>
 
-		<label for="pet-select">Choose a pet:</label>
-		<select name="pets" id="pet-select">
-			<option value="dog">Dog</option>
-			<option value="cat">Cat</option>
-			<option value="hamster">Hamster</option>
-			<option value="parrot">Parrot</option>
-			<option value="spider">Spider</option>
-			<option value="goldfish">Goldfish</option>
-		</select>
+		<ca-form-field>
+			<label for="pet-select">Choose a pet:</label>
+			<select name="pets" id="pet-select">
+				<option value="dog">Dog</option>
+				<option value="cat">Cat</option>
+				<option value="hamster">Hamster</option>
+				<option value="parrot">Parrot</option>
+				<option value="spider">Spider</option>
+				<option value="goldfish">Goldfish</option>
+			</select>
+		</ca-form-field>
 
-		<label for="dino-select">Choose a dinosaur:</label>
-		<select id="dino-select">
-			<optgroup label="Theropods">
-				<option>Tyrannosaurus</option>
-				<option>Velociraptor</option>
-				<option>Deinonychus</option>
-			</optgroup>
-			<optgroup label="Sauropods">
-				<option>Diplodocus</option>
-				<option>Saltasaurus</option>
-				<option>Apatosaurus</option>
-			</optgroup>
-		</select>
+		<ca-form-field>
+			<label for="dino-select">Choose a dinosaur:</label>
+			<select id="dino-select">
+				<optgroup label="Theropods">
+					<option>Tyrannosaurus</option>
+					<option>Velociraptor</option>
+					<option>Deinonychus</option>
+				</optgroup>
+				<optgroup label="Sauropods">
+					<option>Diplodocus</option>
+					<option>Saltasaurus</option>
+					<option>Apatosaurus</option>
+				</optgroup>
+			</select>
+		</ca-form-field>
 
-		<label for="range">Adjust the range slider:</label>
-		<input type="range" name="range" id="range" min="0" max="100" />
+		<ca-form-field>
+			<label for="range">Adjust the range slider:</label>
+			<input type="range" name="range" id="range" min="0" max="100" />
+		</ca-form-field>
 
-		<label for="color">Pick a color:</label>
-		<input type="color" name="color" id="color" />
+		<ca-form-field>
+			<label for="color">Pick a color:</label>
+			<input type="color" name="color" id="color" />
+		</ca-form-field>
 
-		<label for="search">Search:</label>
-		<input type="search" name="search" id="search" />
+		<ca-form-field>
+			<label for="search">Search:</label>
+			<input type="search" name="search" id="search" />
+		</ca-form-field>
 
-		<label for="url">Enter a URL:</label>
-		<input type="url" name="url" id="url" />
+		<ca-form-field>
+			<label for="url">Enter a URL:</label>
+			<input type="url" name="url" id="url" />
+		</ca-form-field>
 
-		<label for="file">Upload a file:</label>
-		<input type="file" name="file" id="file" />
+		<ca-form-field>
+			<label for="file">Upload a file:</label>
+			<input type="file" name="file" id="file" />
+		</ca-form-field>
 
 		<input type="reset" value="Reset" />
 		<input type="submit" value="Submit" />

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -77,5 +77,5 @@
 	</p>
 
 	<h4>Small text</h4>
-	<p><small>A tiny footnote.</small></p>
+	<small>A tiny footnote.</small>
 </main>

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -124,67 +124,85 @@ mark {
  * Forms
  */
 
-/* Default to display:block for most inputs. */
-label,
-input:not([type="radio"], [type="checkbox"]),
-textarea,
-select {
+label {
 	display: block;
 }
 
-/* Increase width for some inputs. */
-input[type="text"],
-input[type="email"],
-input[type="search"],
-input[type="url"],
-textarea {
-	inline-size: 100%;
-	max-inline-size: var(--text-max-width);
+/* Default to display:block for most inputs. */
+input:not([type="radio"], [type="checkbox"], [type="color"]),
+textarea,
+select {
+	display: block;
+	padding: .5rem;
 }
 
-label {
-	/* When a label is followed by an input, add small margin between. */
-	&:has(+ input:not([type="radio"], [type="checkbox"])),
-	&:has(+ textarea),
-	&:has(+ select) {
-		margin-block: 1rem .25rem;
+/* Increase width for some inputs. */
+input:not([type="submit"], [type="reset"], [type="color"]),
+select,
+textarea {
+	inline-size: 100%;
+}
+
+/* No flattened textareas. */
+textarea:not([rows]) {
+	min-block-size: 20ex;
+}
+
+ca-form-field,
+.ca-form-field {
+	margin-block: 1rem 2rem;
+	max-inline-size: var(--text-max-width);
+
+	/* Remove top and bottom margins from first and last children. */
+	& > :first-child {
+		margin-block-start: 0;
+	}
+	& > :last-child {
+		margin-block-end: 0;
 	}
 
-	/* When an input is preceded by a label, add margin after the pair. */
-	& + input:not([type="radio"], [type="checkbox"]),
-	& + textarea,
-	& + select {
-		margin-block: .25rem 1rem;
+	/* Need to add the [invalid] attribute to trigger this. */
+	&:has(*[invalid]) {
+		padding: 1rem;
+		border: .25rem solid red;
 	}
+
+	/* When it's a simple label + input, do a simple vertical flex. */
+	/* We need to allow disclaimer/fine-print text below the input too. */
+	&:has(textarea, select, input:not([type="radio"], [type="checkbox"])) {
+		display: flex;
+		flex-direction: column;
+		gap: .25rem;
+	}
+
+	/* When it's a checkbox or radio button, switch to grid. */
+	/* Consider extending this to other scenarios, such as "initial each paragraph" forms. */
+	&:has(input:is([type="radio"], [type="checkbox"])) {
+		display: grid;
+		grid-template-columns: 1rem auto;
+		grid-template-rows: auto;
+		gap: .25rem 2rem;
+
+		/* All subsequent elements should stay in the second column. */
+		& > :nth-child(n + 3) {
+			grid-column-start: 2;
+		}
+	}
+}
+
+/* Add some buffer when scrolling back up to an invalid field. */
+input:invalid {
+	scroll-margin-block: 5ex;
 }
 
 fieldset {
-	margin-block: 1rem;
+	margin-block: 1rem 2rem;
 	border: none;
 	padding: 0;
 }
 
 legend {
 	margin-block-end: .25rem;
-}
-
-input[type="radio"],
-input[type="checkbox"] {
-	display: inline;
-}
-
-:is(input[type="radio"], input[type="checkbox"]) + label {
-	display: inline;
-
-	&:after {
-		display: block;
-		content: "\A";
-	}
-}
-
-/* No flattened textareas. */
-textarea:not([rows]) {
-	min-height: 10em;
 }
 
 /*

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -128,12 +128,15 @@ h1 + p,
 	margin-bottom: clamp(1.7rem, 1.6363rem + 0.2911vw, 1.875rem);
 }
 
-small,
 .text-small {
 	font-weight: 500;
 	font-size: var(--text-size-small);
 	line-height: var(--text-lineheight-large);
 	margin-bottom: clamp(1.22rem, 1.2091rem + 0.0499vw, 1.25rem);
+}
+
+small {
+	font-size: var(--text-size-small);
 }
 
 code,


### PR DESCRIPTION
The no-`div` experiment with form fields was fun, but ultimately became brittle. This PR adds a `ca-form-field` element to help group and style form fields. Some notes.

* Both `<ca-form-field>` and `<div class="ca-form-field">` are supported.
* I'm using `ca-` instead of `calds-` as the Custom Element prefix, mainly because `calds` feels super annoying to type when I'm working. We can change it later if it's an issue.